### PR TITLE
Modify syntax file to append ' to iskeyword.

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -21,6 +21,9 @@ elseif exists("b:current_syntax") && b:current_syntax == "ocaml"
   finish
 endif
 
+" ' can be used in OCaml identifiers
+set iskeyword+='
+
 " OCaml is case sensitive.
 syn case match
 


### PR DESCRIPTION
' can appear in OCaml identifiers. Adding it to iskeyword lets vim's word movements work as they do in other languages, and also prevents things like match in match' from being highlighted as keywords (utop already does this correctly).

Thanks for the very useful collection of vimfiles! I really appreciate it.