### PR TITLE
Apply iskeyword apostrophe for ocaml only

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -22,7 +22,7 @@ elseif exists("b:current_syntax") && b:current_syntax == "ocaml"
 endif
 
 " ' can be used in OCaml identifiers
-set iskeyword+='
+setlocal iskeyword+='
 
 " OCaml is case sensitive.
 syn case match


### PR DESCRIPTION
Use apostrophe as iskeyword only in ocaml files, do not enforce it globally — other languages might use apostrophes as string separators, and "set isk+='" makes word boundary commands needlessly complicated (most notably, cw eating final separator).