### PR TITLE
Add a .gitignore to ignore doc/tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
This helps having a clean git status when using pathogen and git
submodules. Moreover, you don't want anyone to commit this file.