### PR TITLE
Add a syntax for jbuild files

### DIFF
--- a/ftdetect/jbuild.vim
+++ b/ftdetect/jbuild.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile jbuild set ft=jbuild

--- a/ftplugin/jbuild.vim
+++ b/ftplugin/jbuild.vim
@@ -1,0 +1,6 @@
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin=1
+
+set lisp

--- a/syntax/jbuild.vim
+++ b/syntax/jbuild.vim
@@ -1,0 +1,12 @@
+set syntax=lisp
+
+syn keyword lispDecl jbuild_version library executable executables rule ocamllex ocamlyacc menhir alias install
+
+syn keyword lispKey name public_name synopsis modules libraries wrapped
+syn keyword lispKey preprocess preprocessor_deps optional c_names cxx_names
+syn keyword lispKey install_c_headers modes no_dynlink self_build_stubs_archive
+syn keyword lispKey ppx_runtime_libraries virtual_deps js_of_ocaml link_flags
+syn keyword lispKey javascript_files flags ocamlc_flags ocamlopt_flags pps
+syn keyword lispKey library_flags c_flags c_library_flags kind package action
+
+syn keyword lispAtom true false


### PR DESCRIPTION
Hi,

As mentioned in #15, this project currently lacks `jbuild` support.

This adds highlights toplevel stanzas and common parameters.

Thanks!