### PR TITLE
Remove empty entry from matchit words

### DIFF
--- a/ftplugin/ocaml.vim
+++ b/ftplugin/ocaml.vim
@@ -64,8 +64,7 @@ if !exists("no_plugin_maps") && !exists("no_ocaml_maps")
 endif
 
 " Let % jump between structure elements (due to Issac Trotts)
-let b:mw = ''
-let b:mw = b:mw . ',\<let\>:\<and\>:\(\<in\>\|;;\)'
+let b:mw =         '\<let\>:\<and\>:\(\<in\>\|;;\)'
 let b:mw = b:mw . ',\<if\>:\<then\>:\<else\>'
 let b:mw = b:mw . ',\<\(for\|while\)\>:\<do\>:\<done\>,'
 let b:mw = b:mw . ',\<\(object\|sig\|struct\|begin\)\>:\<end\>'


### PR DESCRIPTION
This fixes the forward scan of %. Previously % would only work when the
cursor was on a matched word, since every other position would match the
empty entry.