### PR TITLE
Remove "raise" from the list of keywords

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -161,7 +161,7 @@ syn keyword  ocamlKeyword  exception external fun
 syn keyword  ocamlKeyword  in inherit initializer
 syn keyword  ocamlKeyword  land lazy let match
 syn keyword  ocamlKeyword  method mutable new nonrec of
-syn keyword  ocamlKeyword  parser private raise rec
+syn keyword  ocamlKeyword  parser private rec
 syn keyword  ocamlKeyword  try type
 syn keyword  ocamlKeyword  virtual when while with
 


### PR DESCRIPTION
It is just a function in `Pervasives` and is otherwise a valid identifier.