### PR TITLE
Add more keywords and match ${...} in jbuild syntax.

### DIFF
--- a/ftplugin/jbuild.vim
+++ b/ftplugin/jbuild.vim
@@ -4,3 +4,5 @@ endif
 let b:did_ftplugin=1
 
 set lisp
+
+setl iskeyword+=#,?,.,/

--- a/syntax/jbuild.vim
+++ b/syntax/jbuild.vim
@@ -1,4 +1,9 @@
 set syntax=lisp
+syn case match
+
+" The syn-iskeyword setting lacks #,? from the iskeyword setting here.
+" Clearing it avoids maintaining keyword characters in multiple places.
+syn iskeyword clear
 
 syn keyword lispDecl jbuild_version library executable executables rule ocamllex ocamlyacc menhir alias install
 
@@ -8,5 +13,17 @@ syn keyword lispKey install_c_headers modes no_dynlink self_build_stubs_archive
 syn keyword lispKey ppx_runtime_libraries virtual_deps js_of_ocaml link_flags
 syn keyword lispKey javascript_files flags ocamlc_flags ocamlopt_flags pps
 syn keyword lispKey library_flags c_flags c_library_flags kind package action
+syn keyword lispKey deps targets locks fallback
 
 syn keyword lispAtom true false
+
+syn keyword lispFunc cat chdir copy# diff? echo run setenv
+syn keyword lispFunc ignore-stdout ignore-stderr ignore-outputs
+syn keyword lispFunc with-stdout-to with-stderr-to with-outputs-to
+syn keyword lispFunc write-file system bash
+
+syn cluster lispBaseListCluster add=jbuildVar
+syn match jbuildVar '\${[@<^]}' containedin=lispSymbol
+syn match jbuildVar '\${\k\+\(:\k\+\)\?}' containedin=lispSymbol
+
+hi def link jbuildVar Identifier


### PR DESCRIPTION
Note the need for `syn iskeyword clear` for `#` and `?` to be recognized an keywords.  Let me know if you prefer a different option.  I also wondered whether the omission of `deps` and `targets` keys is intentional, since they are very common clauses.
