### PR TITLE
Syntactic region for ppx nodes

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -109,6 +109,10 @@ endif
 " "if"
 syn region   ocamlNone matchgroup=ocamlKeyword start="\<if\>" matchgroup=ocamlKeyword end="\<then\>" contains=ALLBUT,@ocamlContained,ocamlThenErr
 
+"" PPX nodes
+
+syn match ocamlPpxIdentifier /\(\[@\{1,3\}\)\@<=\w\+\(\.\w\+\)*/
+syn region ocamlPpx matchgroup=ocamlPpxEncl start="\[@\{1,3\}" contains=TOP end="\]"
 
 "" Modules
 
@@ -302,7 +306,6 @@ if version >= 508 || !exists("did_ocaml_syntax_inits")
   HiLink ocamlScript	   Include
 
   HiLink ocamlConstructor  Constant
-
   HiLink ocamlVal          Keyword
   HiLink ocamlModPreRHS    Keyword
   HiLink ocamlMPRestr2	   Keyword
@@ -328,6 +331,9 @@ if version >= 508 || !exists("did_ocaml_syntax_inits")
   HiLink ocamlTodo	   Todo
 
   HiLink ocamlEncl	   Keyword
+
+  HiLink ocamlPpxEncl       ocamlEncl
+  HiLink ocamlPpxIdentifier Keyword
 
   delcommand HiLink
 endif


### PR DESCRIPTION
This is an attempt to fix the highlighting for `[@@bs.module ...]` (defined by BuckleScript) in external declarations.

This defines a syntactic region `ocamlPpx` between `[@@`/`]` and `[@`/`]` which allows only `ocamlString` inside.

I linked the `ocamlPpx` to `Comment` but this is debatable.

This is how it looked before:
<img width="746" alt="screen shot 2018-04-23 at 00 16 40" src="https://user-images.githubusercontent.com/30594/39099970-9bb02f6e-468b-11e8-9294-6013f233c9aa.png">
... and now this is how it looks:
<img width="746" alt="screen shot 2018-04-23 at 00 15 44" src="https://user-images.githubusercontent.com/30594/39099973-a5ce3eb4-468b-11e8-8602-60750bbaba6b.png">

I'm not into Vim syntax highlighting so I apologise if this fix is silly, at least this highlights (pun intended) the issue.