### PR TITLE
Mirror changes from M. Mottl’s repository

### DIFF
--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -3,6 +3,7 @@
 " Maintainer:  Markus Mottl <markus.mottl@gmail.com>
 " URL:         http://www.ocaml.info/vim/compiler/ocaml.vim
 " Last Change:
+"              2017 Nov 26 - Improved error format (Markus Mottl)
 "              2013 Aug 27 - Added a new OCaml error format (Markus Mottl)
 "              2013 Jun 30 - Initial version (Marc Weber)
 "
@@ -42,6 +43,12 @@ CompilerSet errorformat =
       \%X%*\\a[%*\\d]:\ Leaving\ directory\ `%f',
       \%D%*\\a:\ Entering\ directory\ `%f',
       \%X%*\\a:\ Leaving\ directory\ `%f',
+      \%D%*\\a[%*\\d]:\ Entering\ directory\ '%f',
+      \%X%*\\a[%*\\d]:\ Leaving\ directory\ '%f',
+      \%D%*\\a:\ Entering\ directory\ '%f',
+      \%X%*\\a:\ Leaving\ directory\ '%f',
+      \%DEntering\ directory\ '%f',
+      \%XLeaving\ directory\ '%f',
       \%DMaking\ %*\\a\ in\ %f
 
 let &cpo = s:cpo_save

--- a/ftdetect/ocaml.vim
+++ b/ftdetect/ocaml.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli.cppo,*.ml.cpp set ft=ocaml
+au BufRead,BufNewFile *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli.cppo,*.ml.cppo set ft=ocaml

--- a/ftplugin/jbuild.vim
+++ b/ftplugin/jbuild.vim
@@ -5,4 +5,8 @@ let b:did_ftplugin=1
 
 set lisp
 
+" Comment string
+setl commentstring=;\ %s
+setl comments=:;
+
 setl iskeyword+=#,?,.,/

--- a/ftplugin/sexplib.vim
+++ b/ftplugin/sexplib.vim
@@ -1,0 +1,14 @@
+" Language:    Sexplib
+" Maintainer:  Markus Mottl        <markus.mottl@gmail.com>
+" URL:         http://www.ocaml.info/vim/ftplugin/sexplib.vim
+" Last Change:
+"              2017 Apr 12 - First version (MM)
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin=1
+
+" Comment string
+setl commentstring=;\ %s
+setl comments=:;

--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -5,9 +5,13 @@
 "               Karl-Heinz Sylla  <Karl-Heinz.Sylla@gmd.de>
 "               Issac Trotts      <ijtrotts@ucdavis.edu>
 " URL:          http://www.ocaml.info/vim/syntax/ocaml.vim
-" Last Change:  2015 Jan 21 - Bug fix for comments following included modules (MM)
-"               2014 Oct 09 - added generative functors and quoted strings (MM)
-"               2012 May 12 - Added Dominique Pellé's spell checking patch (MM)
+" Last Change:
+"               2018 Apr 22 - Improved support for PPX (Andrey Popp)
+"               2018 Mar 16 - Remove raise, lnot and not from keywords (Étienne Millon, "copy")
+"               2017 Apr 11 - Improved matching of negative numbers (MM)
+"               2016 Mar 11 - Improved support for quoted strings (Glen Mével)
+"               2015 Aug 13 - Allow apostrophes in identifiers (Jonathan Chan, Einar Lielmanis)
+"               2015 Jun 17 - Added new "nonrec" keyword (MM)
 
 " A minor patch was applied to the official version so that object/end
 " can be distinguished from begin/end, which is used for indentation,
@@ -158,6 +162,9 @@ syn region   ocamlStruct matchgroup=ocamlModule start="\<\(module\s\+\)\=struct\
 syn region   ocamlKeyword start="\<module\>\s*\<type\>\(\s*\<of\>\)\=" matchgroup=ocamlModule end="\<\w\(\w\|'\)*\>" contains=ocamlComment skipwhite skipempty nextgroup=ocamlMTDef
 syn match    ocamlMTDef "=\s*\w\(\w\|'\)*\>"hs=s+1,me=s+1 skipwhite skipempty nextgroup=ocamlFullMod
 
+" Quoted strings
+syn region ocamlString matchgroup=ocamlQuotedStringDelim start="{\z\([a-z_]*\)|" end="|\z1}" contains=@Spell
+
 syn keyword  ocamlKeyword  and as assert class
 syn keyword  ocamlKeyword  constraint else
 syn keyword  ocamlKeyword  exception external fun
@@ -201,7 +208,6 @@ syn match    ocamlCharacter    "'\\x\x\x'"
 syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
-syn match    ocamlString       "{\(\w*\)|\(.\|\n\)\{-}|\1}" contains=@Spell
 
 syn match    ocamlFunDef       "->"
 syn match    ocamlRefAssign    ":="
@@ -226,11 +232,11 @@ else
   syn match    ocamlOperator   "<-"
 endif
 
-syn match    ocamlNumber        "\<-\=\d\(_\|\d\)*[l|L|n]\?\>"
-syn match    ocamlNumber        "\<-\=0[x|X]\(\x\|_\)\+[l|L|n]\?\>"
-syn match    ocamlNumber        "\<-\=0[o|O]\(\o\|_\)\+[l|L|n]\?\>"
-syn match    ocamlNumber        "\<-\=0[b|B]\([01]\|_\)\+[l|L|n]\?\>"
-syn match    ocamlFloat         "\<-\=\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\)\=\>"
+syn match    ocamlNumber        "-\=\<\d\(_\|\d\)*[l|L|n]\?\>"
+syn match    ocamlNumber        "-\=\<0[x|X]\(\x\|_\)\+[l|L|n]\?\>"
+syn match    ocamlNumber        "-\=\<0[o|O]\(\o\|_\)\+[l|L|n]\?\>"
+syn match    ocamlNumber        "-\=\<0[b|B]\([01]\|_\)\+[l|L|n]\?\>"
+syn match    ocamlFloat         "-\=\<\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\)\=\>"
 
 " Labels
 syn match    ocamlLabel        "\~\(\l\|_\)\(\w\|'\)*"lc=1
@@ -324,6 +330,7 @@ if version >= 508 || !exists("did_ocaml_syntax_inits")
   HiLink ocamlNumber	   Number
   HiLink ocamlFloat	   Float
   HiLink ocamlString	   String
+  HiLink ocamlQuotedStringDelim Identifier
 
   HiLink ocamlLabel	   Identifier
 

--- a/syntax/sexplib.vim
+++ b/syntax/sexplib.vim
@@ -3,9 +3,9 @@
 " Filenames:    *.sexp
 " Maintainers:  Markus Mottl      <markus.mottl@gmail.com>
 " URL:          http://www.ocaml.info/vim/syntax/sexplib.vim
-" Last Change:  2012 Jun 20 - Fixed a block comment highlighting bug (MM)
+" Last Change:  2017 Apr 11 - Improved matching of negative numbers (MM)
+"               2012 Jun 20 - Fixed a block comment highlighting bug (MM)
 "               2012 Apr 24 - Added support for new comment styles (MM)
-"               2009 Apr 02 - First release (MM)
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
@@ -30,11 +30,11 @@ syn match    sexplibComment ";.*" contains=sexplibTodo
 " Atoms
 syn match    sexplibUnquotedAtom /\([^;()" \t#|]\|#[^;()" \t|]\||[^;()" \t#]\)[^;()" \t]*/
 syn region   sexplibQuotedAtom    start=+"+ skip=+\\\\\|\\"+ end=+"+
-syn match    sexplibNumber        "\<-\=\d\(_\|\d\)*[l|L|n]\?\>"
-syn match    sexplibNumber        "\<-\=0[x|X]\(\x\|_\)\+[l|L|n]\?\>"
-syn match    sexplibNumber        "\<-\=0[o|O]\(\o\|_\)\+[l|L|n]\?\>"
-syn match    sexplibNumber        "\<-\=0[b|B]\([01]\|_\)\+[l|L|n]\?\>"
-syn match    sexplibFloat         "\<-\=\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\)\=\>"
+syn match    sexplibNumber        "-\=\<\d\(_\|\d\)*[l|L|n]\?\>"
+syn match    sexplibNumber        "-\=\<0[x|X]\(\x\|_\)\+[l|L|n]\?\>"
+syn match    sexplibNumber        "-\=\<0[o|O]\(\o\|_\)\+[l|L|n]\?\>"
+syn match    sexplibNumber        "-\=\<0[b|B]\([01]\|_\)\+[l|L|n]\?\>"
+syn match    sexplibFloat         "-\=\<\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\)\=\>"
 
 " Lists
 syn region   sexplibEncl transparent matchgroup=sexplibEncl start="(" matchgroup=sexplibEncl end=")" contains=ALLBUT,sexplibParenErr


### PR DESCRIPTION
This is an attempt to resync files found [there](https://github.com/mmottl/vim-files/blob/master/.vim/) with their descendants here. Changes are indicated in bold.

Files which were modified only here (not updated by this PR):
  + *`ftdetect/ocaml.vim`* (except that I fixed a typo)
  + `ftplugin/ocaml.vim` (but what is the purpose of commit 0672bcf ?)

Files which were modified only there (fast‐forward updating):
  + **`compiler/ocaml.vim`**
  + **`syntax/sexplib.com`**
  + `ftdetect/sexplib.com`: I did not include the changes ([1](https://github.com/mmottl/vim-files/commit/42e809e6446fa755ff9bb5ad8d9ce32a4f446d86#diff-1be10d2e4e1c29c41820bde2b8c112c4), [2](https://github.com/mmottl/vim-files/commit/35ca5d16aeb442e4899fa5291328599d7811df20)) because they conflict with our `ftdetect/jbuild.vim` (mmottl gives jbuild/dune files the “sexplib” filetype while we give them the “jbuild” filetype).

New file:
  + **`ftplugin/sexplib.vim`**: because here we treat “sexplib” and “jbuild” files separately (see above), I also included the contents of that new file into **`ftplugin/jbuild.vim`** (by the way, there are competing syntax files `syntax/sexplib.vim` and `syntax/jbuild.vim`, maybe some bits of the former would be relevant for the latter).

Files which required merging:
  + `ftdetect/omake.vim`: I did not include [the change](https://github.com/mmottl/vim-files/commit/51d8048443a43fc90ebccdd4736fd2d85e4b01fd) because `ftdetect` is not the right place to set `'noexpandtab'`.
  + **`syntax/ocaml.vim`**:
      - competing changes were made in both versions to support PPX nodes, I picked the implementation from here since it is more accurate (uses `:syn region`, highlights the contents of the node);
      - similarly, there were competing changes for quoted strings, and I picked mmottl’s version for the same reason (in particular, issue #8 should be closed — but I think that it was already the case);
      - I included all other changes of both sides;
      - to keep track of which changes I merged, I added them to the “Last Change” header, with the name of the authors as found on Github (this means that for now, more than 3 changes are listed).