### PR TITLE
add missing keywords to `opam.vim`

### DIFF
--- a/syntax/opam.vim
+++ b/syntax/opam.vim
@@ -4,7 +4,7 @@ endif
 
 " need %{vars}%
 " env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]
-syn keyword opamKeyword1 remove depends depopts conflicts env packages patches version maintainer tags license homepage authors doc install author available name depexts substs
+syn keyword opamKeyword1 remove depends depopts conflicts env packages patches version maintainer tags license homepage authors doc install author available name depexts substs synopsis description
 syn match opamKeyword2 "\v(bug-reports|post-messages|ocaml-version|opam-version|dev-repo|build-test|build-doc|build)"
 
 syn keyword opamTodo FIXME NOTE NOTES TODO XXX contained


### PR DESCRIPTION
now that description/synopsis are mandatory, they should definitely be highlighted