### PR TITLE
Add missing directives to `syntax/ocaml.vim`

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -38,7 +38,7 @@ syn match    ocamlMethod       "#"
 syn match    ocamlComment   "^#!.*" contains=@Spell
 
 " Scripting directives
-syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|directory\|cd\|load\|use\|install_printer\|remove_printer\|require\|thread\|trace\|untrace\|untrace_all\|print_depth\|print_length\|camlp4o\)\>"
+syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|directory\|cd\|load\|load_rec\|use\|mod_use\|install_printer\|remove_printer\|require\|list\|predicates\|thread\|trace\|untrace\|untrace_all\|print_depth\|print_length\|camlp4o\|camlp4r\)\>"
 
 " lowercase identifier - the standard way to match
 syn match    ocamlLCIdentifier /\<\(\l\|_\)\(\w\|'\)*\>/


### PR DESCRIPTION
This commit highlights 5 more preprocessing directives: `#load_rec`, `#mod_use`, `#list`, `#predicates`, `#camlp4r`. The first 2 are standard (I think?). The last 3 are Findlib directives.