### PR TITLE
Also highlight named parameters between parentheses

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -241,7 +241,7 @@ syn match    ocamlFloat         "-\=\<\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(
 " Labels
 syn match    ocamlLabel        "\~\(\l\|_\)\(\w\|'\)*"lc=1
 syn match    ocamlLabel        "?\(\l\|_\)\(\w\|'\)*"lc=1
-syn region   ocamlLabel transparent matchgroup=ocamlLabel start="?(\(\l\|_\)\(\w\|'\)*"lc=2 end=")"me=e-1 contains=ALLBUT,@ocamlContained,ocamlParenErr
+syn region   ocamlLabel transparent matchgroup=ocamlLabel start="[~?](\(\l\|_\)\(\w\|'\)*"lc=2 end=")"me=e-1 contains=ALLBUT,@ocamlContained,ocamlParenErr
 
 
 " Synchronization


### PR DESCRIPTION
Until now, named parameters were highlighted in the following situations:

  * `?name` accounts for these constructions:
      + simple optional λ-binders: `fun ?name -> expr`
      + optional parameter passing: `f ?name`, `f ?name:expr`
      + optional parameters in function types: `?name:typ -> typ`
  * `?(name …)` accounts for these:
      + optional λ-binders with typing annotations and/or default values: `?(name : typ)`, `?(name = expr)`, `?(name : typ = expr)`.
  * `~name` accounts for these:
      + simple non-optional λ-binders: `fun ~name -> expr`
      + non-optional parameter passing: `f ~name`, `f ~name:expr`

This commit adds highlighting in the following situation:

  * `~(name …)` accounts for these:
      + non-optional λ-binders with typing annotations: `?(name : typ)`.

---

### A related wish

What is still missing is highlighting non-optional parameters in function types: `name:typ -> typ`. Highlighting these is desirable to me, particularly for .mli files, so I have been thinking about it. This is mostly impossible because the syntax has no recognizable `~`, so we essentially need to match anything of the shape `name :`, which of course has countless conflicts (beware, below follow many lists with many bullets — I _really_ want this):

  * named parameters: occurrences already mentioned above (not a problem)
  * records: `{ name : typ }`, `{ r with name : typ }` (I would tend to consider it an opportune side effect)
  * value declarations: `val name : typ`
  * typing annotations on bindings:
      + `fun`: `fun name : typ -> expr`, `fun pat name : typ -> expr`
      + `let`, `external`: similar
      + `val` (for objects): similar
      + `method`: similar
      + record fields: see above
      + maybe others I could not think of
  * typing annotations for expressions and patterns: `(name : typ)`
  * coercions: `(name :>  typ)`, `(expr : name :> typ)`
  * list constructions: `name :: expr`
  * assignation operators: `name := expr`

We can filter out many of these
  * by looking at the character just after `:` and rule out `>`, `:` and `=` (those cannot be the beginning of a type expression);
  * by looking at the last non-blank character before the `name`, and rule out anything alphanumeric (including keywords like `with`, `let`…);
  * by allowing no space between the `name` and `:`; this is not complete but relies on a sensible coding style;
  * by enabling the highlight rule only for .mli files?

Alternatively, we may enumerate which tokens of the grammar can precede the type expression `name:typ -> typ`:
  * `:`
  * `:>`
  * `of` (valid for polymorphic variants but not for ADTs, apparently)
  * `&` — as in ```[< `A of & name:int -> int & name:bool -> bool ]``` (idem)
  * `=`
  * `.` — as in `'a . typexpr`
  * `->`
  * `(`
  * `,` —  as in `( typexpr , typexpr ) t` and `[ typexpr , typexpr ] classpath`
  * `[` — as in`[ typexpr ] classpath`
  * `constraint typexpr`

(

However, we need not consider the following contexts:
  * `typexpr * typexpr` (because of precedence between `*` and `->`, this would be a syntax error)
  * `[ typexpr | typexpr ]` (this would cause a type error)

)

Of these tokens, we may restrict the match to the most common ones, ie. `=`, `:` and `->` — I am unsure about `(`. But even with the first three, false positives remain:

    (fun name -> name : int -> int)    (* uncommon pattern, I think *)
    (expr = name : typ -> typ)    (* well, to make it typecheck, you have to do it on purpose *)
    (* … probably others I could not think of right now … *)

To me, that’s good enough for realistic code.

In any case, we will never get rid of the ambiguity between the type expression `( name : int -> bool )` (where `name` is of type `int`) and the value expression `( name : int -> bool )` (where `name` is of type `int->bool` (!!!)).

    type t   =  ( name : int -> bool ) ;;  (* here “name” is of type int *)
    type t   =  { name : int -> bool } ;;  (* here “name” is of type int->bool *)
    fun name -> ( name : int -> bool ) ;;  (* here “name” is of type int->bool *)