### PR TITLE
Improve syntax highlighting for OCaml operators

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -6,6 +6,7 @@
 "               Issac Trotts      <ijtrotts@ucdavis.edu>
 " URL:          http://www.ocaml.info/vim/syntax/ocaml.vim
 " Last Change:
+"               2018 Nov 08 - Improved highlighting of operators (Maëlan)
 "               2018 Apr 22 - Improved support for PPX (Andrey Popp)
 "               2018 Mar 16 - Remove raise, lnot and not from keywords (Étienne Millon, "copy")
 "               2017 Apr 11 - Improved matching of negative numbers (MM)
@@ -170,7 +171,7 @@ syn keyword  ocamlKeyword  constraint else
 syn keyword  ocamlKeyword  exception external fun
 
 syn keyword  ocamlKeyword  in inherit initializer
-syn keyword  ocamlKeyword  land lazy let match
+syn keyword  ocamlKeyword  lazy let match
 syn keyword  ocamlKeyword  method mutable new nonrec of
 syn keyword  ocamlKeyword  parser private rec
 syn keyword  ocamlKeyword  try type
@@ -182,14 +183,11 @@ if exists("ocaml_revised")
 else
   syn keyword  ocamlKeyword  function
   syn keyword  ocamlBoolean  true false
-  syn match    ocamlKeyChar  "!"
 endif
 
 syn keyword  ocamlType     array bool char exn float format format4
 syn keyword  ocamlType     int int32 int64 lazy_t list nativeint option
 syn keyword  ocamlType     string unit
-
-syn keyword  ocamlOperator asr lor lsl lsr lxor mod
 
 syn match    ocamlConstructor  "(\s*)"
 syn match    ocamlConstructor  "\[\s*\]"
@@ -209,27 +207,49 @@ syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
 
-syn match    ocamlFunDef       "->"
-syn match    ocamlRefAssign    ":="
 syn match    ocamlTopStop      ";;"
-syn match    ocamlOperator     "\^"
-syn match    ocamlOperator     "::"
 
-syn match    ocamlOperator     "&&"
-syn match    ocamlOperator     "<"
-syn match    ocamlOperator     ">"
 syn match    ocamlAnyVar       "\<_\>"
 syn match    ocamlKeyChar      "|[^\]]"me=e-1
 syn match    ocamlKeyChar      ";"
 syn match    ocamlKeyChar      "\~"
 syn match    ocamlKeyChar      "?"
-syn match    ocamlKeyChar      "\*"
-syn match    ocamlKeyChar      "="
 
+"" Operators
+
+" The grammar of operators is found there:
+"     https://caml.inria.fr/pub/docs/manual-ocaml/names.html#operator-name
+"     https://caml.inria.fr/pub/docs/manual-ocaml/extn.html#s:ext-ops
+"     https://caml.inria.fr/pub/docs/manual-ocaml/extn.html#s:index-operators
+" =, *, < and > are both operator names and keywords, we let the user choose how
+" to display them (has to be declared before regular infix operators):
+syn match    ocamlEqual        "="
+syn match    ocamlStar         "*"
+syn match    ocamlAngle        "<"
+syn match    ocamlAngle        ">"
+" Custom indexing operators:
+syn match    ocamlIndexingOp   "\.[~?!:|&$%=>@^/*+-][~?!.:|&$%<=>@^*/+-]*\(()\|\[]\|{}\)\(<-\)\?"
+" Extension operators (has to be declared before regular infix operators):
+syn match    ocamlExtensionOp          "#[#~?!.:|&$%<=>@^*/+-]\+"
+" Infix and prefix operators:
+syn match    ocamlPrefixOp              "![~?!.:|&$%<=>@^*/+-]*"
+syn match    ocamlPrefixOp           "[~?][~?!.:|&$%<=>@^*/+-]\+"
+syn match    ocamlInfixOp      "[&$%@^/+-][~?!.:|&$%<=>@^*/+-]*"
+syn match    ocamlInfixOp         "[|<=>*][~?!.:|&$%<=>@^*/+-]\+"
+syn match    ocamlInfixOp               "#[~?!.:|&$%<=>@^*/+-]\+#\@!"
+syn match    ocamlInfixOp              "!=[~?!.:|&$%<=>@^*/+-]\@!"
+syn keyword  ocamlInfixOp      asr land lor lsl lsr lxor mod or
+" := is technically an infix operator, but we may want to show it as a keyword
+" (somewhat analogously to = for let‐bindings and <- for assignations):
+syn match    ocamlRefAssign    ":="
+" :: is technically not an operator, but we may want to show it as such:
+syn match    ocamlCons         "::"
+" -> and <- are keywords, not operators (but can appear in longer operators):
+syn match    ocamlArrow        "->[~?!.:|&$%<=>@^*/+-]\@!"
 if exists("ocaml_revised")
-  syn match    ocamlErr        "<-"
+  syn match    ocamlErr        "<-[~?!.:|&$%<=>@^*/+-]\@!"
 else
-  syn match    ocamlOperator   "<-"
+  syn match    ocamlKeyChar    "<-[~?!.:|&$%<=>@^*/+-]\@!"
 endif
 
 syn match    ocamlNumber        "-\=\<\d\(_\|\d\)*[l|L|n]\?\>"
@@ -318,12 +338,23 @@ if version >= 508 || !exists("did_ocaml_syntax_inits")
   HiLink ocamlMPRestr2	   Keyword
   HiLink ocamlKeyword	   Keyword
   HiLink ocamlMethod	   Include
-  HiLink ocamlFunDef	   Keyword
-  HiLink ocamlRefAssign    Keyword
+  HiLink ocamlArrow	   Keyword
   HiLink ocamlKeyChar	   Keyword
   HiLink ocamlAnyVar	   Keyword
   HiLink ocamlTopStop	   Keyword
-  HiLink ocamlOperator	   Keyword
+
+  HiLink ocamlRefAssign    ocamlKeyChar
+  HiLink ocamlEqual        ocamlKeyChar
+  HiLink ocamlStar         ocamlInfixOp
+  HiLink ocamlAngle        ocamlInfixOp
+  HiLink ocamlCons         ocamlInfixOp
+
+  HiLink ocamlPrefixOp     ocamlOperator
+  HiLink ocamlInfixOp      ocamlOperator
+  HiLink ocamlExtensionOp  ocamlOperator
+  HiLink ocamlIndexingOp   ocamlOperator
+
+  HiLink ocamlOperator     Operator
 
   HiLink ocamlBoolean	   Boolean
   HiLink ocamlCharacter    Character


### PR DESCRIPTION
Ping @mmottl who showed interest in this (you can also check out the other PRs).

This PR reworks completely how OCaml operators are highlighted. Before this PR:

 1. only a finite, small subset of operators were recognized; as a consequence:
      + not all operators were shown the same way: some were highlighted, some weren’t (most notably, `*` and `<` were highlighted but `+` and `/` weren’t);
      + in some operators, different characters had different styles (for example, only the tilde was highlighted in `~-`, only the star was highlighted in `*.`; and in `1--2`, the second minus sign was considered to be part of the integer literal);
 2. some were matched as keywords;
 3. all recognized operators were displayed with the same style as keywords.

With this PR:

 1. (hopefully) all operators, as described by the grammar in the OCaml manual, are recognized;
 2. when ambiguities are unavoidable, the user can choose what to do;
 3. operators have a distinct style.

**Regarding bullet 1.** This includes infix operators, prefix operators, custom indexing operators and extension operators. Custom indexing operators are only recognized when written as `( .![] )`, not in infix syntax `a.![i]`. Maybe something could be done here.

**Regarding bullet 2.** Tokens `=`, `*`, `<` and `>` are both operators and keywords (the last 3 relate to type expressions: tuple types and object types). This is a conflict we cannot solve, so we have to make a choice. By default, `=` is shown as a keyword, whereas `*`, `<` and `>` are shown as operators (because they are more common that way). To let the user choose something else, this PR introduces one dedicated matchgroup for each of these: `ocamlEqual`, `ocamlStar` and `ocamlAngle`.

Additionally, although `:=` technically is an operator, by default it is highlighted as a keyword. The corresponding matchgroup is called `ocamlRefAssign` (it existed before this PR). This is by analogy with `=` and `<-`.

At last, by default the list constructor `::` is highlighted as an operator, although it is not one. The matchgroup is `ocamlCons`.

**Regarding bullet 3.** operators now link to the Vim-standard matchgroup `Operator`. Of course the user can change this at will.

The animation below gives a visual idea of the change:
![highlight-operators](https://user-images.githubusercontent.com/1915526/48303692-8136fc00-e50d-11e8-81cb-3c3d48dfd2fd.gif)